### PR TITLE
Test to avoid unnecessary warning with user defined distance

### DIFF
--- a/R/matchit.R
+++ b/R/matchit.R
@@ -36,7 +36,8 @@ matchit <- function(formula, data, method = "nearest", distance = "logit",
 
   ## obtain T and X
   tryerror <- try(model.frame(formula), TRUE)
-  if (distance %in% c("GAMlogit", "GAMprobit", "GAMcloglog", "GAMlog", "GAMcauchit")) {
+  if (is.character(distance) &&
+        distance %in% c("GAMlogit", "GAMprobit", "GAMcloglog", "GAMlog", "GAMcauchit")) {
     requireNamespace("mgcv")
     tt <- terms(mgcv::interpret.gam(formula)$fake.formula)
   } else {


### PR DESCRIPTION
Avoid an unnecessary warning when a user defined distance is provided.

```
Warning message:
In if (distance %in% c("GAMlogit", "GAMprobit", "GAMcloglog", "GAMlog",  :
  the condition has length > 1 and only the first element will be used
```