### PR TITLE
Allow a user specified distance matrix in full matching

### DIFF
--- a/R/matchit2full.R
+++ b/R/matchit2full.R
@@ -9,13 +9,19 @@ matchit2full <- function(treat, X, data, distance, discarded, is.full.mahalanobi
   ddd <- distance[!discarded]
   n0 <- length(ttt[ttt==0])
   n1 <- length(ttt[ttt==1])
-  d1 <- ddd[ttt==1]
-  d0 <- ddd[ttt==0]
-  d <- matrix(0, ncol=n0, nrow=n1)
-  rownames(d) <- names(ttt[ttt==1])
-  colnames(d) <- names(ttt[ttt==0])
-  for (i in 1:n1) 
-    d[i,] <- abs(d1[i]-d0)
+
+  if(!is.matrix(distance)){
+    d1 <- ddd[ttt==1]
+    d0 <- ddd[ttt==0]
+    d <- matrix(0, ncol=n0, nrow=n1)
+    rownames(d) <- names(ttt[ttt==1])
+    colnames(d) <- names(ttt[ttt==0])
+    for (i in 1:n1)  
+      d[i,] <- abs(d1[i]-d0)
+  } else {
+    d <- distance
+    d <- d[treat == 0 & !discarded, treat == 1 & !discarded] 
+  }
   full <- optmatch::fullmatch(d, ...)
   psclass <- full[pmatch(names(ttt), names(full))]
   psclass <- as.numeric(as.factor(psclass))

--- a/R/matchit2full.R
+++ b/R/matchit2full.R
@@ -20,7 +20,7 @@ matchit2full <- function(treat, X, data, distance, discarded, is.full.mahalanobi
       d[i,] <- abs(d1[i]-d0)
   } else {
     d <- distance
-    d <- d[treat == 0 & !discarded, treat == 1 & !discarded] 
+    d <- d[treat == 1 & !discarded, treat == 0 & !discarded] 
   }
   full <- optmatch::fullmatch(d, ...)
   psclass <- full[pmatch(names(ttt), names(full))]

--- a/R/matchit2full.R
+++ b/R/matchit2full.R
@@ -10,7 +10,10 @@ matchit2full <- function(treat, X, data, distance, discarded, is.full.mahalanobi
   n0 <- length(ttt[ttt==0])
   n1 <- length(ttt[ttt==1])
 
-  if(!is.matrix(distance)){
+  if(is.matrix(distance)){
+    d <- distance
+    d <- d[treat == 1 & !discarded, treat == 0 & !discarded] 
+  } else {
     d1 <- ddd[ttt==1]
     d0 <- ddd[ttt==0]
     d <- matrix(0, ncol=n0, nrow=n1)
@@ -18,10 +21,7 @@ matchit2full <- function(treat, X, data, distance, discarded, is.full.mahalanobi
     colnames(d) <- names(ttt[ttt==0])
     for (i in 1:n1)  
       d[i,] <- abs(d1[i]-d0)
-  } else {
-    d <- distance
-    d <- d[treat == 1 & !discarded, treat == 0 & !discarded] 
-  }
+  } 
   full <- optmatch::fullmatch(d, ...)
   psclass <- full[pmatch(names(ttt), names(full))]
   psclass <- as.numeric(as.factor(psclass))


### PR DESCRIPTION
Instead of expecting a indiv -> control means distance, I thought it would make sense use a full subject x subject matrix. My use case was full matching, but this would potentially be useful for other matching types as well if it's not implemented yet. Optmatch for example can take a treated x control distance matrix. 

Also, this is presently undocumented as far as I can tell - it might be worth mentioning in the manual that matchit expects a distance vector to centre of the control distribution to save confusion.