### PR TITLE
Fix for match.data

### DIFF
--- a/R/match.data.R
+++ b/R/match.data.R
@@ -3,11 +3,10 @@ match.data <- function(object, group = "all", distance = "distance",
                        weights = "weights", subclass = "subclass") {
 
   if (!is.null(object$model)) {
-    env <- attributes(terms(object$model))$.Environment
+    data <- object$model$data
   } else {
-    env <- parent.frame()
+    data <- eval(object$call$data, envir = parent.frame())
   }
-  data <- eval(object$call$data, envir = env)
   treat <- object$treat
   wt <- object$weights
   vars <- names(data)


### PR DESCRIPTION
The `matchit` object stores a full copy of the `data.frame` at `m$model$data` but still uses `data <- eval(object$call$data, envir = env)` to retrieve the `data.frame`. This is a problem in many cases because the reference `object$call$data` might not exist anymore. For example, simply removing the `data.frame` used in `matchit` leads to an error. Here is an example:

```
library("MatchIt")
library("purrr")

# Everything works
data(lalonde)
test <- lalonde 
m.out1 <- matchit(treat ~ re74 + re75 + age + educ, data = test, method = "nearest", distance = "logit")
match.data(m.out1)
# However, when the `test` object doesn't exist anymore, `match.data` fails
rm(test)
match.data(m.out1)
```

My changes to `match.data` fix this problem and still fall back on the old method when `m$model` is `NULL`.