### PR TITLE
Make `matchit2nearest` compatible with tibble

### DIFF
--- a/R/matchit2_methods.R
+++ b/R/matchit2_methods.R
@@ -354,6 +354,7 @@ matchit2nearest <-  function(treat, X, data, distance, discarded,
     ## out another way to compare a vector with the matrix
     if (!is.null(exact)) {
       for (k in 1:dim(exact)[2]) matchedc2[exact[itert,k]!=exact[clabels,k]] <- -2
+      for (k in 1:dim(exact)[2]) matchedc2[exact[[k]][itert]!=exact[[k]][clabels]] <- -2
     }
     
     ## Need to add a check in case there aren't any eligible matches left...

--- a/R/matchit2_methods.R
+++ b/R/matchit2_methods.R
@@ -353,7 +353,6 @@ matchit2nearest <-  function(treat, X, data, distance, discarded,
     ## There might be a more efficient way to do this, but I couldn't figure
     ## out another way to compare a vector with the matrix
     if (!is.null(exact)) {
-      for (k in 1:dim(exact)[2]) matchedc2[exact[itert,k]!=exact[clabels,k]] <- -2
       for (k in 1:dim(exact)[2]) matchedc2[exact[[k]][itert]!=exact[[k]][clabels]] <- -2
     }
     


### PR DESCRIPTION
`tibble` is a replacement for `data.frame` and part of the extremely popular tidyverse packages developed by Hadley Wickham (see tibble description [here](https://blog.rstudio.com/2016/03/24/tibble-1-0-0/)). `matchit2nearest` with the `exact` option is not compatible with `tibble`. The reason is that `tibble` always return a `tibble` and do not suddenly return a vector like `data.frame` for something like `df[1,1]`. This commit fixes the problem so that `matchit` with the `exact` option works when the user uses a `tibble` for the `data` argument. Here is some code to illustrate.

```
library("MatchIt")
library("tibble")

data(lalonde)
# works...
matchit(treat ~ re74 + re75 + age + educ, data = lalonde, method = "nearest", distance = "logit", exact = "black")
# matchit fails when I use a tibble for the data argument
matchit(treat ~ re74 + re75 + age + educ, data = as_tibble(lalonde), method = "nearest", distance = "logit", exact = "black")
# with this pull request, both data.frame and tibble work
```