### PR TITLE
Fixed plot hist par mfrow change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: MatchIt
-Version: 3.0.2
+Version: 3.0.3
 Date: 2018-01-09
 Title: Nonparametric Preprocessing for Parametric Causal Inference
 Description: Selects matched samples of the original treated and

--- a/R/hist.pscore.R
+++ b/R/hist.pscore.R
@@ -57,4 +57,5 @@ hist.pscore <- function(x, numdraws=5000, xlab="Propensity Score", main=NULL, fr
        main=main,...)
     if(!is.null(q.cut)){abline(v=q.cut,col="grey",lty=1)}
   }
+  par(mfrow=c(1,1))
 }

--- a/R/hist.pscore.R
+++ b/R/hist.pscore.R
@@ -23,6 +23,7 @@ hist.pscore <- function(x, numdraws=5000, xlab="Propensity Score", main=NULL, fr
     pscore.treated.matched <- pscore[treat==1 & weights!=0]
     pscore.control.matched <- pscore[treat==0 & weights!=0]
   }
+  par_prior <- par(no.readonly = TRUE) ## Store prior par config before changing
   par(mfrow=c(2,2))
   if(!is.null(xlim)){warning("xlim may not be user specified. xlim returned to default.")}
   xlim <- range(na.omit(pscore))
@@ -57,5 +58,5 @@ hist.pscore <- function(x, numdraws=5000, xlab="Propensity Score", main=NULL, fr
        main=main,...)
     if(!is.null(q.cut)){abline(v=q.cut,col="grey",lty=1)}
   }
-  par(mfrow=c(1,1))
+  par(mfrow = par_prior$mfrow) # Reset to prior par config
 }

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -10,9 +10,9 @@ test_that("hist.pscore correctly restores par() settings", {
   m.out <- matchit(treat ~ educ + black + hispan, data = lalonde,
                    method = "nearest")
   
-  par_prior <- par(no.readonly = TRUE)
+  par_prior <- par(no.readonly = TRUE)$mfrow
   plot(m.out, type="hist")
-  par_now <- par(no.readonly = TRUE)
+  par_now <- par(no.readonly = TRUE)$mfrow
   
   # tests
   expect_equal(par_prior, par_now)

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -1,0 +1,19 @@
+
+library(testthat)
+library(MatchIt)
+data("lalonde")
+
+context("hist.pscore")
+
+test_that("hist.pscore correctly restores par() settings", {
+  # setup test
+  m.out <- matchit(treat ~ educ + black + hispan, data = lalonde,
+                   method = "nearest")
+  
+  par_prior <- par(no.readonly = TRUE)
+  plot(m.out, type="hist")
+  par_now <- par(no.readonly = TRUE)
+  
+  # tests
+  expect_equal(par_prior, par_now)
+})

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -10,10 +10,10 @@ test_that("hist.pscore correctly restores par() settings", {
   m.out <- matchit(treat ~ educ + black + hispan, data = lalonde,
                    method = "nearest")
   
-  par_prior <- par(no.readonly = TRUE)$mfrow
+  par_mfrow_prior <- par(no.readonly = TRUE)$mfrow
   plot(m.out, type="hist")
-  par_now <- par(no.readonly = TRUE)$mfrow
+  par_mfrow_now <- par(no.readonly = TRUE)$mfrow
   
   # tests
-  expect_equal(par_prior, par_now)
+  expect_equal(par_mfrow_prior, par_mfrow_now)
 })


### PR DESCRIPTION
When applying `plot(m.out, type = "hist")` I observed that the plot does not change back from `par(mfrow=c(2,2))`. Since `c(1,1)` is the default value I added it to the hist.pscore function.
When I tried with devtools this solved the issue for me.
Alternatively, I thought about storing the prior "mfrow" value but could not find the function to obtain it. Otherwise, I tried `dev.off()` to reset to user default values, but this did not work.