### PR TITLE
Fix incorrect build logic in MakeVars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,3 @@
 strippedLib: $(SHLIB)
-	if test -e "/usr/bin/strip" & test -e "/bin/uname" & [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi
+	if test -e "/usr/bin/strip" && test -e "/bin/uname" && [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug $(SHLIB); fi
 .phony: strippedLib


### PR DESCRIPTION
The current code in MakeVars contains incorrect log﻿ic: the `&` operator in bash sends commands to the background, while what's wanted is the `&&` operator. With the current code, if `/usr/bin/strip` does not exist then errors occur during the build:

```
       > /nix/store/s5hkav7whndbfz0szshpb46h4idqdq9a-gcc-wrapper-10.3.0/bin/c++ -std=gnu++11 -shared -L/nix/store/h89y1fr8dkr1m9f95nyy0i5lybbn3dwl-R-4.1.1/lib/R/lib -o MatchIt.so RcppExports.o internal.o nn_matchC.o pairdistC.o subclass2mm.o tabulateC.o weights_matrixC.o -L/nix/store/h89y1fr8dkr1m9f95nyy0i5lybbn3dwl-R-4.1.1/lib/R/lib -lR
       > if test -e "/usr/bin/strip" & test -e "/bin/uname" & [[ `uname` == "Linux" ]] ; then /usr/bin/strip --strip-debug MatchIt.so; fi
       > /nix/store/wadmyilr414n7bimxysbny876i2vlm5r-bash-5.1-p8/bin/bash: line 1: /usr/bin/strip: No such file or directory
       > make: *** [Makevars:2: strippedLib] Error 127
       > ERROR: compilation failed for package 'MatchIt'
```

This patch fixes the logic and corrects the build on systems without `/usr/bin/strip`.
