### PR TITLE
Add methods to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Depends:
     R (>= 3.5.0)
 Imports:
     backports (>= 1.1.9),
-    Rcpp (>= 1.0.10)
+    Rcpp (>= 1.0.10),
+    methods
 Suggests:
     optmatch (>= 0.10.6),
     Matching,


### PR DESCRIPTION
As introduced here:

https://github.com/kosukeimai/MatchIt/blob/ea40f25584f5cb3a9038f3c8dfa3b65049bd4582/R/RcppExports.R#L33

I'm not 100% certain the rules around build-time dependencies on default packages, but nevertheless it seems like a good idea to include it.