### PR TITLE
Fix issue #171

### DIFF
--- a/R/matchit2optimal.R
+++ b/R/matchit2optimal.R
@@ -375,7 +375,7 @@ matchit2optimal <- function(treat, formula, data, distance, discarded,
   pair <- setNames(rep(NA_character_, length(treat)), names(treat))
   p <- setNames(vector("list", nlevels(ex)), levels(ex))
 
-  t_df <- data.frame(treat)
+  t_df <- data.frame(treat_)
 
   for (e in levels(ex)[cc]) {
     if (nlevels(ex) > 1) {


### PR DESCRIPTION
Fix issue #171 in `matchit2optimal` by ensuring that the filtered version of `treat` (`treat_`) is used rather than the unfiltered version. This means that the selection of rows in `t_df` using `ex` will work appropriately.